### PR TITLE
Set default value in JsonRpcController::getArrayRequest() to fix missing params

### DIFF
--- a/src/Traits/JsonRpcController.php
+++ b/src/Traits/JsonRpcController.php
@@ -21,7 +21,7 @@ trait JsonRpcController
     protected function getArrayRequest(): array
     {
         if (null === $this->arrayRequest) {
-            return ArrayHelper::fromObject($this->getRequest()->call->params);
+            return ArrayHelper::fromObject($this->getRequest()->call->params ?? []);
         }
 
         return $this->arrayRequest;


### PR DESCRIPTION
This PR fixes an ErrorException, when using JsonRpcController::getArrayRequest() in a call which has no params.