### PR TITLE
Fixes for Lumen 5.6

### DIFF
--- a/src/Middleware/AssociateParamsMiddleware.php
+++ b/src/Middleware/AssociateParamsMiddleware.php
@@ -4,6 +4,7 @@ namespace Tochka\JsonRpc\Middleware;
 
 use Tochka\JsonRpc\Exceptions\JsonRpcException;
 use Tochka\JsonRpc\JsonRpcRequest;
+use Tochka\JsonRpc\Helpers\ArrayHelper;
 
 class AssociateParamsMiddleware implements BaseMiddleware
 {
@@ -19,6 +20,8 @@ class AssociateParamsMiddleware implements BaseMiddleware
     public function handle($request)
     {
         $api_params = !empty($request->call->params) ? (array)$request->call->params : [];
+
+        $api_params = ArrayHelper::fromObject($api_params);
 
         // подготавливаем аргументы для вызова метода
         $reflectionMethod = new \ReflectionMethod($request->controller, $request->method);

--- a/src/Traits/JsonRpcController.php
+++ b/src/Traits/JsonRpcController.php
@@ -46,7 +46,7 @@ trait JsonRpcController
      * @return bool|MessageBag Прошла валидация или нет
      * @throws InvalidParametersException
      */
-    protected function validate($rules, array $messages = [], $noException = false)
+    protected function validateParams($rules, array $messages = [], $noException = false)
     {
         return $this->validateData($this->getArrayRequest(), $rules, $messages, $noException);
     }


### PR DESCRIPTION
Hi! I'd like to introduce 2 fixes that prevent usage of JSON-RPC server on currently available Lumen framework.
1. The Trait, validate method is already exists in Lumen controller classes with another signature and visibility class, yieldind errors during syntax checks. I've change the name to validateParams
2. Lumen passes request params not the same way Laravel does. It passes them as array of stdClass objects instead of array of strings. This yields in inability to check named params in AssociateParamsMiddleware.
Thus we have to convert them to array of strings using helper method. After this update middleware function properly on both Lumen 5.6 and Laravel
