### PR TITLE
по красоте отдаем ответ кириллицей - без всяких utf-8 последовательно…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea
 vendor
 composer.lock
+/nbproject

--- a/src/JsonRpcServer.php
+++ b/src/JsonRpcServer.php
@@ -3,6 +3,7 @@
 namespace Tochka\JsonRpc;
 
 use Illuminate\Http\Request;
+use Illuminate\Http\Response;
 use Tochka\JsonRpc\Facades\JsonRpcHandler;
 use Tochka\JsonRpc\Handlers\AuthHandler;
 use Tochka\JsonRpc\Handlers\BaseHandler;
@@ -64,8 +65,9 @@ class JsonRpcServer
             $answer->error = JsonRpcHandler::handle($e);
             $this->response[] = $answer;
         }
+        $content = \count($this->response) > 1 ? $this->response : (array)$this->response[0];
 
-        return \count($this->response) > 1 ? $this->response : (array)$this->response[0];
+        return new Response(json_encode($content, JSON_UNESCAPED_UNICODE), Response::HTTP_OK, ['Content-Type' => 'application/json']);
     }
 
     public function setResponse($response): void


### PR DESCRIPTION
Устраняем экранирование кириллицы последовательностями utf-8.
Сейчас так:
```
{"jsonrpc":"2.0","id":1,"error":{"code":3,"message":"\u0421\u0431\u043e\u0439 \u0430\u0432\u0442\u043e\u0440\u0438\u0437\u0430\u0446\u0438\u0438 - \u0434\u043e\u0441\u0442\u0443\u043f \u0437\u0430\u043f\u0440\u0435\u0449\u0451\u043d"}}
```
Предлагаю сделать так:
```
{"jsonrpc":"2.0","id":1,"error":{"code":3,"message":"Сбой авторизации - доступ запрещён"}}
```