### PR TITLE
setting custom method delimiter

### DIFF
--- a/src/Support/JsonRpcHandleResolver.php
+++ b/src/Support/JsonRpcHandleResolver.php
@@ -8,7 +8,14 @@ use Tochka\JsonRpc\Exceptions\JsonRpcException;
 
 class JsonRpcHandleResolver
 {
+    protected $methodDelimiter = '_';
+
     protected $controllerSuffix = 'Controller';
+
+    public function setMethodDelimiter(string $delimiter): void
+    {
+        $this->methodDelimiter = $delimiter;
+    }
 
     public function setControllerSuffix(string $suffix): void
     {
@@ -134,7 +141,7 @@ class JsonRpcHandleResolver
             $methodCall = $request->call->method;
 
             // парсим имя метода
-            $methodArray = explode('_', $methodCall);
+            $methodArray = explode($this->methodDelimiter, $methodCall);
 
             if (count($methodArray) < 2) {
                 throw new JsonRpcException(JsonRpcException::CODE_METHOD_NOT_FOUND);

--- a/tests/Support/JsonRpcHandleResolverTest.php
+++ b/tests/Support/JsonRpcHandleResolverTest.php
@@ -21,6 +21,20 @@ class JsonRpcHandleResolverTest extends TestCase
     }
 
     /**
+     * @covers \Tochka\JsonRpc\Support\JsonRpcHandleResolver::setMethodDelimiter
+     * @throws \ReflectionException
+     */
+    public function testSetMethodDelimiter(): void
+    {
+        $delimiter = 'same';
+
+        $this->resolver->setMethodDelimiter($delimiter);
+        $actualDelimiter = $this->getProperty($this->resolver, 'methodDelimiter');
+
+        $this->assertEquals($delimiter, $actualDelimiter);
+    }
+
+    /**
      * @covers \Tochka\JsonRpc\Support\JsonRpcHandleResolver::setControllerSuffix
      * @throws \ReflectionException
      */


### PR DESCRIPTION
I want to be able to change the default method delimiter, e.g. to use period instead of underscore.

controller_method -> controller.method